### PR TITLE
make use of the forked buildpack-php-nginx

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -114,8 +114,8 @@ api = "0.7"
     version = "0.2.21"
 
   [[order.group]]
-    id = "paketo-buildpacks/php-nginx"
-    version = "0.3.7"
+    id = "ninech/buildpack-php-nginx"
+    version = "0.0.3"
 
   [[order.group]]
     id = "paketo-buildpacks/php-memcached-session-handler"

--- a/package.toml
+++ b/package.toml
@@ -21,7 +21,7 @@
   uri = "urn:cnb:registry:paketo-buildpacks/php-httpd@0.3.21"
 
 [[dependencies]]
-  uri = "urn:cnb:registry:paketo-buildpacks/php-nginx@0.3.7"
+  uri = "ghcr.io/ninech/buildpack-php-nginx:0.0.3"
 
 [[dependencies]]
   uri = "urn:cnb:registry:paketo-buildpacks/php-builtin-server@0.4.20"


### PR DESCRIPTION
This makes use of the forked buildpack-php-nginx buildpack.